### PR TITLE
Add restore properties for NuGet in CI and include packages lock file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           global-json-file: global.json
           cache: 'true'
-          cache-dependency-path: '**/package-lock.json'
+          cache-dependency-path: '**/packages.lock.json'
 
       - name: Set Default TAG
         run: echo "TAG=v0.0.0" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           global-json-file: global.json
           cache: 'true'
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Set Default TAG
         run: echo "TAG=v0.0.0" >> $GITHUB_ENV

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,9 @@
 <Project>
+    <!-- NuGet Restore -->
+    <PropertyGroup>
+        <RestoreLockedMode Condition="'$(CI)' == 'true'">true</RestoreLockedMode>
+        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    </PropertyGroup>
     <!-- SourceLink -->
     <PropertyGroup>
         <RepositoryType>git</RepositoryType>

--- a/src/Escendit.Tools.CodeAnalysis.xUnitAnalyzers/packages.lock.json
+++ b/src/Escendit.Tools.CodeAnalysis.xUnitAnalyzers/packages.lock.json
@@ -1,0 +1,47 @@
+{
+  "version": 2,
+  "dependencies": {
+    ".NETStandard,Version=v2.0": {
+      "Escendit.Tools.Branding": {
+        "type": "Direct",
+        "requested": "[1.2.0, )",
+        "resolved": "1.2.0",
+        "contentHash": "Tleka3RGcnG623z+4nxdGKINEQn9roCuNOPe0UHqckl4tndXfXEkWezEx011apR45Lqvc33KKrRnlDKv9kbRQQ=="
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Direct",
+        "requested": "[1.23.0, )",
+        "resolved": "1.23.0",
+        "contentHash": "WCkO1FPTWoESLhghoXA881CulRYpve0UrXLsL5aYcLQd9SlD+oADb16NAP+SE5o3w0FM2MzGTklBwY8yUfj0ng=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      }
+    },
+    ".NETStandard,Version=v2.1": {
+      "Escendit.Tools.Branding": {
+        "type": "Direct",
+        "requested": "[1.2.0, )",
+        "resolved": "1.2.0",
+        "contentHash": "Tleka3RGcnG623z+4nxdGKINEQn9roCuNOPe0UHqckl4tndXfXEkWezEx011apR45Lqvc33KKrRnlDKv9kbRQQ=="
+      },
+      "xunit.analyzers": {
+        "type": "Direct",
+        "requested": "[1.23.0, )",
+        "resolved": "1.23.0",
+        "contentHash": "WCkO1FPTWoESLhghoXA881CulRYpve0UrXLsL5aYcLQd9SlD+oADb16NAP+SE5o3w0FM2MzGTklBwY8yUfj0ng=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #13 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved NuGet package restore reliability and consistency by enabling lock file usage and locked mode during continuous integration builds.
  * Added a lock file to ensure consistent package versions for dependencies.
  * Enhanced build workflow caching by using lock files to optimize dependency restoration in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->